### PR TITLE
Await Project#toLeopard

### DIFF
--- a/lib/convertProject.ts
+++ b/lib/convertProject.ts
@@ -34,8 +34,8 @@ ${content}`;
   }
 }
 
-export function exportProjectWithBufferAssetsToZip(project: Project): JSZip {
-  const converted = project.toLeopard({});
+export async function exportProjectWithBufferAssetsToZip(project: Project): Promise<JSZip> {
+  const converted = await project.toLeopard({});
   postProcessLeopardFiles(converted);
 
   const zip = new JSZip();
@@ -65,7 +65,7 @@ export function exportProjectWithBufferAssetsToZip(project: Project): JSZip {
 export async function exportProjectWithURLAssetsToCodeSandbox(
   project: Project,
 ): Promise<string> {
-  const converted = project.toLeopard({});
+  const converted = await project.toLeopard({});
   postProcessLeopardFiles(converted);
 
   let files: { [name: string]: { content: string; isBinary: boolean } } = {};

--- a/pages/api/[projectId]/leopard-website.ts
+++ b/pages/api/[projectId]/leopard-website.ts
@@ -37,7 +37,7 @@ export default async function convertToLeopardWebsite(
       },
     });
 
-    const converted = project.toLeopard();
+    const converted = await project.toLeopard();
 
     let assetUploadPromises = [];
     let alreadyUploadedAssetNames: Set<string> = new Set();

--- a/pages/api/[projectId]/zip.ts
+++ b/pages/api/[projectId]/zip.ts
@@ -39,7 +39,7 @@ export default async function convertToZip(
       },
     });
 
-    const convertedZip = exportProjectWithBufferAssetsToZip(project);
+    const convertedZip = await exportProjectWithBufferAssetsToZip(project);
     const buffer = await convertedZip.generateAsync({ type: "nodebuffer" });
     res.setHeader("Content-Type", "application/zip");
     res.setHeader("Content-Disposition", "attachment; filename=converted.zip");

--- a/pages/api/upload/zip.ts
+++ b/pages/api/upload/zip.ts
@@ -27,7 +27,7 @@ export default async function uploadToZip(
       },
     });
 
-    const convertedZip = exportProjectWithBufferAssetsToZip(project);
+    const convertedZip = await exportProjectWithBufferAssetsToZip(project);
     const buffer = await convertedZip.generateAsync({ type: "nodebuffer" });
     res.setHeader("Content-Type", "application/zip");
     res.setHeader("Content-Disposition", "attachment; filename=converted.zip");


### PR DESCRIPTION
Preparation for using Prettier v3 in sb-edit's Leopard exporter, which switches to an async API because the JavaScript gods have decreed that async = good and sync = bad, even for CPU-bound tasks.