### PR TITLE
Connection pooling

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,6 +11,11 @@ DIRECT_DATABASE_URL=
 # *In development, it should be the same as DIRECT_DATABASE_URL*
 DATABASE_URL=
 
+# Set to true to enable same-domain previews. This allows you to preview projects on the same domain as the editor.
+# This is not safe in production (where project previews must be served from a subdomain), but it can simplify
+# your development environment.
+NEXT_PUBLIC_UNSAFE_SAME_DOMAIN_PREVIEWS=false
+
 # The AWS access key ID and secret access key for your account. These are used to access the S3 buckets.
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=

--- a/.env.template
+++ b/.env.template
@@ -5,6 +5,10 @@
 NEXT_PUBLIC_BASE_URL=http://localhost.test:3000
 
 # The postgres database URL. This is usually in the format postgresql://username:password@host:port/database?schema=schema
+DIRECT_DATABASE_URL=
+
+# The (proxied) database URL. In staging and production this might be a Prisma Accelerate URI (prisma://...).
+# *In development, it should be the same as DIRECT_DATABASE_URL*
 DATABASE_URL=
 
 # The AWS access key ID and secret access key for your account. These are used to access the S3 buckets.

--- a/app/$preview/[subdomain]/[[...path]]/route.tsx
+++ b/app/$preview/[subdomain]/[[...path]]/route.tsx
@@ -2,6 +2,10 @@ import { NextRequest } from "next/server";
 import prisma from "../../../../lib/prisma";
 import { getAssetURL } from "../../../../lib/previewURLs";
 
+// Use "Edge" runtime on Vercel. Ideally this will be faster.
+export const runtime =
+  process.env.NODE_ENV === "development" ? "nodejs" : "edge";
+
 export async function GET(
   req: NextRequest,
   {

--- a/lib/previewURLs.ts
+++ b/lib/previewURLs.ts
@@ -1,8 +1,14 @@
 export function getPreviewURL(projectId: string, path: string) {
   let url = new URL(path, process.env.NEXT_PUBLIC_BASE_URL);
 
-  // Add subdomain to URL host
-  url.host = [projectId, "preview", ...url.host.split(".")].join(".");
+  if (process.env.NEXT_PUBLIC_UNSAFE_SAME_DOMAIN_PREVIEWS === "true") {
+    // Special case: If this flag is enabled, load previews from the same domain
+    // rather than a subdomain
+    url.pathname = `/$preview/${projectId}${url.pathname}`;
+  } else {
+    // Add subdomain to URL host
+    url.host = [projectId, "preview", ...url.host.split(".")].join(".");
+  }
 
   return url;
 }

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,7 +1,8 @@
 import { PrismaClient } from "@prisma/client";
+import { withAccelerate } from "@prisma/extension-accelerate";
 
 const prismaClientSingleton = () => {
-  return new PrismaClient();
+  return new PrismaClient().$extends(withAccelerate());
 };
 
 declare global {

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,5 +1,10 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient as PrismaClientNode } from "@prisma/client";
+import { PrismaClient as PrismaClientEdge } from "@prisma/client/edge";
 import { withAccelerate } from "@prisma/extension-accelerate";
+
+const PrismaClient = process.env.DATABASE_URL?.startsWith("prisma://")
+  ? PrismaClientEdge
+  : PrismaClientNode;
 
 const prismaClientSingleton = () => {
   return new PrismaClient().$extends(withAccelerate());

--- a/middleware.ts
+++ b/middleware.ts
@@ -30,6 +30,17 @@ export async function middleware(request: NextRequest) {
     request.nextUrl.pathname.startsWith("$") || // I have no idea if the non-/ version is needed here but I'm including it to be on the safe side
     request.nextUrl.pathname.startsWith("/$")
   ) {
+    // Exception: If unsafe same-domain previews are enabled, allow
+    // $preview paths to be loaded directly
+    if (process.env.NEXT_PUBLIC_UNSAFE_SAME_DOMAIN_PREVIEWS === "true") {
+      if (
+        request.nextUrl.pathname.startsWith("$preview") ||
+        request.nextUrl.pathname.startsWith("/$preview")
+      ) {
+        return NextResponse.next();
+      }
+    }
+
     // Return a 404 for any requests to these paths
     return NextResponse.error();
   }

--- a/middleware.ts
+++ b/middleware.ts
@@ -21,14 +21,6 @@ export async function middleware(request: NextRequest) {
         ),
       );
     }
-
-    // Any other subdomains are invalid
-    if (subdomains.length > 0) {
-      // Redirect to the root domain
-      return NextResponse.redirect(
-        new URL("/", process.env.NEXT_PUBLIC_BASE_URL),
-      );
-    }
   }
 
   // Block URLs begining with $. We will use that as our convention for paths

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@headlessui/react": "^2.0.3",
         "@monaco-editor/react": "^4.6.0",
-        "@prisma/client": "^5.15.1",
+        "@prisma/client": "^5.16.2",
+        "@prisma/extension-accelerate": "^1.1.0",
         "aws-sdk": "^2.1261.0",
         "bcrypt": "^5.1.1",
         "classnames": "^2.3.1",
@@ -45,7 +46,7 @@
         "postcss": "^8.4.14",
         "prettier": "^3.1.1",
         "prettier-plugin-tailwindcss": "^0.5.9",
-        "prisma": "^5.15.1",
+        "prisma": "^5.16.2",
         "tailwindcss": "^3.4.3",
         "typescript": "^4.9.5"
       }
@@ -689,9 +690,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.15.1.tgz",
-      "integrity": "sha512-fmZRGmsUJ9+VwC/AvfP/PwdpD0xAEyPvNsD9/B3+GYpETq9VejVRT3PiqNvl76q1uYYzNZeo8u/LmzzTetHSEg==",
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.16.2.tgz",
+      "integrity": "sha512-+1lmkhR9gHWcTC5oghm2ZKpWljyWdzfazCVlLKUWXVmwHSf52g81aZ8qb6Km5Bs025yBi7puLp3qSLEvktoUtw==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=16.13"
@@ -706,48 +707,59 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.15.1.tgz",
-      "integrity": "sha512-NQjdEplhXEcPvf84ghxExC+LD+iTimbg3sZvA3BhybVQIocBEBxFf9GTHhmRVPmjrWoBaYJBVgEEBXZT27JTbQ==",
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.16.2.tgz",
+      "integrity": "sha512-ItzB4nR4O8eLzuJiuP3WwUJfoIvewMHqpGCad+64gvThcKEVOtaUza9AEJo2DPqAOa/AWkFyK54oM4WwHeew+A==",
       "devOptional": true
     },
     "node_modules/@prisma/engines": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.15.1.tgz",
-      "integrity": "sha512-1iTRxJEFvpBpEWf2bYiMG6LBBQhX7X+GA5piH+tmPWgc/v+/ElxQf2kjQxby8AErmZqtZkdoKJ7FSRjNjBPE9Q==",
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.16.2.tgz",
+      "integrity": "sha512-qUxwMtrwoG3byd4PbX6T7EjHJ8AUhzTuwniOGkh/hIznBfcE2QQnGakyEq4VnwNuttMqvh/GgPFapHQ3lCuRHg==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/debug": "5.15.1",
-        "@prisma/engines-version": "5.15.1-1.5675a3182f972f1a8f31d16eee6abf4fd54910e3",
-        "@prisma/fetch-engine": "5.15.1",
-        "@prisma/get-platform": "5.15.1"
+        "@prisma/debug": "5.16.2",
+        "@prisma/engines-version": "5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303",
+        "@prisma/fetch-engine": "5.16.2",
+        "@prisma/get-platform": "5.16.2"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "5.15.1-1.5675a3182f972f1a8f31d16eee6abf4fd54910e3",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.15.1-1.5675a3182f972f1a8f31d16eee6abf4fd54910e3.tgz",
-      "integrity": "sha512-7csphKGCG6n/cN1MkT1mJvQ78Ir18IknlYZ8eyEoLKdQBb0HscR/6TyPmzqrMA7Rz01K1KeXqctwAqxtA/lKQg==",
+      "version": "5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303.tgz",
+      "integrity": "sha512-HkT2WbfmFZ9WUPyuJHhkiADxazHg8Y4gByrTSVeb3OikP6tjQ7txtSUGu9OBOBH0C13dPKN2qqH12xKtHu/Hiw==",
       "devOptional": true
     },
+    "node_modules/@prisma/extension-accelerate": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/extension-accelerate/-/extension-accelerate-1.1.0.tgz",
+      "integrity": "sha512-sESjhBZ4ywQjAVpKzsfhxyNu+9txIM5I6M1MPBaJBq/xDlqmniIAhlwIEt9KLtO80zqPxqbZYes18zrkgYqNiQ==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@prisma/client": ">=4.16.1"
+      }
+    },
     "node_modules/@prisma/fetch-engine": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.15.1.tgz",
-      "integrity": "sha512-mj0wfsJ+mAdDp1ynT2JKxAXa+CoYMT267qF7g2Uv+oaVTI2CMfGWouMARht8T2QLTgl+gpXSFTwIYbcR+oWEtw==",
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.16.2.tgz",
+      "integrity": "sha512-sq51lfHKfH2jjYSjBtMjP+AznFqOJzXpqmq6B9auWrlTJrMgZ7lPyhWUW7VU7LsQU48/TJ+DZeIz8s9bMYvcHg==",
       "devOptional": true,
       "dependencies": {
-        "@prisma/debug": "5.15.1",
-        "@prisma/engines-version": "5.15.1-1.5675a3182f972f1a8f31d16eee6abf4fd54910e3",
-        "@prisma/get-platform": "5.15.1"
+        "@prisma/debug": "5.16.2",
+        "@prisma/engines-version": "5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303",
+        "@prisma/get-platform": "5.16.2"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.15.1.tgz",
-      "integrity": "sha512-oFccp7bYys+ZYkmtYzjR+0cRrGKvSuF+h5QhSkyEsYQ9kzJzQRvuWt2SiHRPt8xOQ4MTmujM+bP5uOexnnAHdQ==",
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.16.2.tgz",
+      "integrity": "sha512-cXiHPgNLNyj22vLouPVNegklpRL/iX2jxTeap5GRO3DmCoVyIHmJAV1CgUMUJhHlcol9yYy7EHvsnXTDJ/PKEA==",
       "devOptional": true,
       "dependencies": {
-        "@prisma/debug": "5.15.1"
+        "@prisma/debug": "5.16.2"
       }
     },
     "node_modules/@react-aria/focus": {
@@ -6364,13 +6376,13 @@
       }
     },
     "node_modules/prisma": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.15.1.tgz",
-      "integrity": "sha512-pYsUVpTlYvZ6mWvZKDv9rKdUa7tlfSUJY1CVtgb8Had1pHbIm9fr1MBASccr5XnSuCUrjnvKhWNwgSYy6aCajA==",
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.16.2.tgz",
+      "integrity": "sha512-rFV/xoBR2hBGGlu4LPLQd4U8WVA+tSAmYyFWGPRVfj+xg7N4kiZV4lSk38htSpF+/IuHKzlrbh4SFk8Z18cI8A==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "5.15.1"
+        "@prisma/engines": "5.16.2"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -8861,53 +8873,59 @@
       "optional": true
     },
     "@prisma/client": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.15.1.tgz",
-      "integrity": "sha512-fmZRGmsUJ9+VwC/AvfP/PwdpD0xAEyPvNsD9/B3+GYpETq9VejVRT3PiqNvl76q1uYYzNZeo8u/LmzzTetHSEg==",
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.16.2.tgz",
+      "integrity": "sha512-+1lmkhR9gHWcTC5oghm2ZKpWljyWdzfazCVlLKUWXVmwHSf52g81aZ8qb6Km5Bs025yBi7puLp3qSLEvktoUtw==",
       "requires": {}
     },
     "@prisma/debug": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.15.1.tgz",
-      "integrity": "sha512-NQjdEplhXEcPvf84ghxExC+LD+iTimbg3sZvA3BhybVQIocBEBxFf9GTHhmRVPmjrWoBaYJBVgEEBXZT27JTbQ==",
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.16.2.tgz",
+      "integrity": "sha512-ItzB4nR4O8eLzuJiuP3WwUJfoIvewMHqpGCad+64gvThcKEVOtaUza9AEJo2DPqAOa/AWkFyK54oM4WwHeew+A==",
       "devOptional": true
     },
     "@prisma/engines": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.15.1.tgz",
-      "integrity": "sha512-1iTRxJEFvpBpEWf2bYiMG6LBBQhX7X+GA5piH+tmPWgc/v+/ElxQf2kjQxby8AErmZqtZkdoKJ7FSRjNjBPE9Q==",
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.16.2.tgz",
+      "integrity": "sha512-qUxwMtrwoG3byd4PbX6T7EjHJ8AUhzTuwniOGkh/hIznBfcE2QQnGakyEq4VnwNuttMqvh/GgPFapHQ3lCuRHg==",
       "devOptional": true,
       "requires": {
-        "@prisma/debug": "5.15.1",
-        "@prisma/engines-version": "5.15.1-1.5675a3182f972f1a8f31d16eee6abf4fd54910e3",
-        "@prisma/fetch-engine": "5.15.1",
-        "@prisma/get-platform": "5.15.1"
+        "@prisma/debug": "5.16.2",
+        "@prisma/engines-version": "5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303",
+        "@prisma/fetch-engine": "5.16.2",
+        "@prisma/get-platform": "5.16.2"
       }
     },
     "@prisma/engines-version": {
-      "version": "5.15.1-1.5675a3182f972f1a8f31d16eee6abf4fd54910e3",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.15.1-1.5675a3182f972f1a8f31d16eee6abf4fd54910e3.tgz",
-      "integrity": "sha512-7csphKGCG6n/cN1MkT1mJvQ78Ir18IknlYZ8eyEoLKdQBb0HscR/6TyPmzqrMA7Rz01K1KeXqctwAqxtA/lKQg==",
+      "version": "5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303.tgz",
+      "integrity": "sha512-HkT2WbfmFZ9WUPyuJHhkiADxazHg8Y4gByrTSVeb3OikP6tjQ7txtSUGu9OBOBH0C13dPKN2qqH12xKtHu/Hiw==",
       "devOptional": true
     },
+    "@prisma/extension-accelerate": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/extension-accelerate/-/extension-accelerate-1.1.0.tgz",
+      "integrity": "sha512-sESjhBZ4ywQjAVpKzsfhxyNu+9txIM5I6M1MPBaJBq/xDlqmniIAhlwIEt9KLtO80zqPxqbZYes18zrkgYqNiQ==",
+      "requires": {}
+    },
     "@prisma/fetch-engine": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.15.1.tgz",
-      "integrity": "sha512-mj0wfsJ+mAdDp1ynT2JKxAXa+CoYMT267qF7g2Uv+oaVTI2CMfGWouMARht8T2QLTgl+gpXSFTwIYbcR+oWEtw==",
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.16.2.tgz",
+      "integrity": "sha512-sq51lfHKfH2jjYSjBtMjP+AznFqOJzXpqmq6B9auWrlTJrMgZ7lPyhWUW7VU7LsQU48/TJ+DZeIz8s9bMYvcHg==",
       "devOptional": true,
       "requires": {
-        "@prisma/debug": "5.15.1",
-        "@prisma/engines-version": "5.15.1-1.5675a3182f972f1a8f31d16eee6abf4fd54910e3",
-        "@prisma/get-platform": "5.15.1"
+        "@prisma/debug": "5.16.2",
+        "@prisma/engines-version": "5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303",
+        "@prisma/get-platform": "5.16.2"
       }
     },
     "@prisma/get-platform": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.15.1.tgz",
-      "integrity": "sha512-oFccp7bYys+ZYkmtYzjR+0cRrGKvSuF+h5QhSkyEsYQ9kzJzQRvuWt2SiHRPt8xOQ4MTmujM+bP5uOexnnAHdQ==",
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.16.2.tgz",
+      "integrity": "sha512-cXiHPgNLNyj22vLouPVNegklpRL/iX2jxTeap5GRO3DmCoVyIHmJAV1CgUMUJhHlcol9yYy7EHvsnXTDJ/PKEA==",
       "devOptional": true,
       "requires": {
-        "@prisma/debug": "5.15.1"
+        "@prisma/debug": "5.16.2"
       }
     },
     "@react-aria/focus": {
@@ -13086,12 +13104,12 @@
       "requires": {}
     },
     "prisma": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.15.1.tgz",
-      "integrity": "sha512-pYsUVpTlYvZ6mWvZKDv9rKdUa7tlfSUJY1CVtgb8Had1pHbIm9fr1MBASccr5XnSuCUrjnvKhWNwgSYy6aCajA==",
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.16.2.tgz",
+      "integrity": "sha512-rFV/xoBR2hBGGlu4LPLQd4U8WVA+tSAmYyFWGPRVfj+xg7N4kiZV4lSk38htSpF+/IuHKzlrbh4SFk8Z18cI8A==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "5.15.1"
+        "@prisma/engines": "5.16.2"
       }
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "next start",
     "lint": "next lint",
     "format": "prettier --write --ignore-path .gitignore .",
-    "vercel-build": "prisma migrate deploy && prisma generate && next build"
+    "vercel-build": "prisma migrate deploy && prisma generate --no-engine && next build"
   },
   "author": "Josh Pullen",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@headlessui/react": "^2.0.3",
     "@monaco-editor/react": "^4.6.0",
-    "@prisma/client": "^5.15.1",
+    "@prisma/client": "^5.16.2",
+    "@prisma/extension-accelerate": "^1.1.0",
     "aws-sdk": "^2.1261.0",
     "bcrypt": "^5.1.1",
     "classnames": "^2.3.1",
@@ -51,7 +52,7 @@
     "postcss": "^8.4.14",
     "prettier": "^3.1.1",
     "prettier-plugin-tailwindcss": "^0.5.9",
-    "prisma": "^5.15.1",
+    "prisma": "^5.16.2",
     "tailwindcss": "^3.4.3",
     "typescript": "^4.9.5"
   }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,8 +6,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_DATABASE_URL")
 }
 
 enum Role {


### PR DESCRIPTION
Not sure how this is gonna go, but we're sending it and can revert if needed.

## Why do we need connection pooling?
When previewing a project, every request is sent through the route `app/$preview/[subdomain]/[[..path]]/route.tsx`. This route fetches the file from the database and then returns it (or a redirect to the S3 asset). This means that every load of every file is hitting the database.

Hitting the database is fine, but in Vercel's serverless environment this means a new database **connection** for every asset request. For large projects, this meant that [clicking the green flag once could essentially take down the website for a second](https://scratch.mit.edu/discuss/topic/420162/?page=53#post-8045064).

We need connection pooling.

## Why use Prisma Accelerate?
I looked at different options, and it seems like the most straightforward way by far is to use [Prisma Accelerate](https://www.prisma.io/data-platform/accelerate). (We are using only the connection pooling, not the cache.) AWS also provides a pooling option but it doesn't work with Prisma client, which we use.

> "Prisma ORM is compatible with AWS RDS Proxy. However, there is no benefit in using it for connection pooling with Prisma ORM due to the way RDS Proxy pins connections." - [Prisma Docs](https://www.prisma.io/docs/orm/prisma-client/deployment/caveats-when-deploying-to-aws-platforms#aws-rds-proxy)

I hate the vendor lock-in of being stuck with using Prisma's services, so this could change at some point in the future. Especially if it turns out to be expensive. Fortunately, I don't think it would be _toooo_ challenging to back out of this choice in the future if needed. (We would just need to do the work of finding a replacement method.)

## Bonus update: The Edge™️

One benefit of using Prisma Accelerate is that it's now possible to run Prisma client in an "Edge" environment. (We are no longer connecting to `postgres://` which requires drivers that only work in Node. Instead, Prisma client is communicating with the Prisma Accelerate layer via `http://`, which works on the edge.)

So I've enabled the Vercel Edge environment for project previews in the hopes that it will be faster.

I don't have a clear understanding of what makes the edge environment different, so this is mostly a close-your-eyes-and-hope-the-hyped-tech-is-better decision. But it feels intuitively good, I guess, to have a simple-but-frequently-hit route be booted into a smaller, simpler runtime.